### PR TITLE
UUID Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target
+
+*.prefs
+.project
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.4.5-R0.2-SNAPSHOT</version>
+            <version>1.7.9-R0.1-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <!-- End Bukkit -->

--- a/src/main/java/net/krinsoft/ranksuite/RankCore.java
+++ b/src/main/java/net/krinsoft/ranksuite/RankCore.java
@@ -4,6 +4,8 @@ import net.krinsoft.ranksuite.commands.CommandHandler;
 import net.krinsoft.ranksuite.events.RankSuiteRankChangeEvent;
 import net.krinsoft.ranksuite.events.RankSuiteRankResetEvent;
 import net.krinsoft.ranksuite.util.FancyParser;
+
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
@@ -27,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 /**
@@ -38,10 +41,11 @@ public class RankCore extends JavaPlugin {
     private final static Pattern NEXT = Pattern.compile("\\[new\\]");
     private final static Pattern USER = Pattern.compile("\\[user\\]");
 
-    private FileConfiguration db;
+    private FileConfiguration players_db;
+	private FileConfiguration uuids_db;
 
     private LinkedHashMap<String, Integer> leaders = new LinkedHashMap<String, Integer>();
-    private LinkedList<String> logins = new LinkedList<String>();
+    private LinkedList<UUID> logins = new LinkedList<UUID>();
 
     private int leaderTask;
     private int updateTask;
@@ -50,7 +54,7 @@ public class RankCore extends JavaPlugin {
     private CommandHandler commands;
 
     private Map<String, Rank> ranks = new HashMap<String, Rank>();
-    private Map<String, RankedPlayer> players = new HashMap<String, RankedPlayer>();
+    private Map<UUID, RankedPlayer> players = new HashMap<UUID, RankedPlayer>();
 
     private boolean debug = false;
     private boolean log_ranks = true;
@@ -85,7 +89,7 @@ public class RankCore extends JavaPlugin {
                 getLogger().info("Rankings imported.");
             }
         }
-        getDB();
+        getPlayersDB();
 
         // create the leaderboard
         this.leaderTask = getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable() {
@@ -100,10 +104,10 @@ public class RankCore extends JavaPlugin {
         // register a scheduled task to update players dynamically
         this.updateTask = getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable() {
             public void run() {
-                for (String name : players.keySet()) {
-                    promote(name);
+                for (UUID uuid : players.keySet()) {
+                    promote(uuid);
                 }
-                saveDB();
+                savePlayersDB();
             }
         }, 1L, 6000L);
 
@@ -111,8 +115,8 @@ public class RankCore extends JavaPlugin {
         this.loginTask = getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable() {
             public void run() {
                 if (logins.size() > 0) {
-                    for (String name : logins) {
-                        promote(name);
+                    for (UUID uuid : logins) {
+                        promote(uuid);
                     }
                     logins.clear();
                 }
@@ -121,7 +125,7 @@ public class RankCore extends JavaPlugin {
     }
 
     public void onDisable() {
-        saveDB();
+        savePlayersDB();
         getServer().getScheduler().cancelTasks(this);
         getServer().getScheduler().cancelTask(this.leaderTask);
         getServer().getScheduler().cancelTask(this.updateTask);
@@ -133,20 +137,62 @@ public class RankCore extends JavaPlugin {
         return true;
     }
 
-    public FileConfiguration getDB() {
-        if (db == null) {
-            db = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "players.db"));
+    @Deprecated
+    public FileConfiguration getPlayersDB() {
+        if (players_db == null) {
+        	players_db = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "players.db"));
         }
-        return db;
+        return players_db;
     }
 
-    public void saveDB() {
+    @Deprecated
+    public void savePlayersDB() {
         try {
-            db.save(new File(getDataFolder(), "players.db"));
+            players_db.save(new File(getDataFolder(), "players.db"));
         } catch (IOException e) {
             getLogger().warning("An error occurred while saving the players database.");
         }
     }
+    
+    public FileConfiguration getUuidDB() {
+		if (uuids_db == null) {
+			uuids_db = YamlConfiguration.loadConfiguration(new File(
+					getDataFolder(), "uuids.db"));
+		}
+		return uuids_db;
+	}
+
+	public void saveUuidDB() {
+		try {
+			uuids_db.save(new File(getDataFolder(), "uuids.db"));
+		} catch (IOException e) {
+			getLogger().warning(
+					"An error occurred while saving the uuids database.");
+		}
+	}
+	
+	/**
+	 * One time method to move data from players.db to uuids.db
+	 * 
+	 * @param name
+	 *            The name of the player
+	 */
+	public void transfer(String name, UUID uuid) {
+		// Check if we already converted
+		if (this.getPlayersDB().getInt(name.toLowerCase()) == -1) {
+			return;
+		}
+		if (this.getUuidDB().getInt(uuid.toString()) == 0) {
+			int time = this.getPlayersDB().getInt(name.toLowerCase());
+			debug("Converted [" + name + "] to [" + uuid.toString()
+					+ "] in storage, with [" + time + "] minutes");
+			this.getUuidDB().set(uuid.toString(), time);
+			this.getPlayersDB().set(name.toLowerCase(), -1);
+			this.savePlayersDB();
+			this.saveUuidDB();
+			this.buildLeaderboard();
+		}
+	}
 
     public CommandHandler getCommandHandler() {
         return this.commands;
@@ -188,10 +234,10 @@ public class RankCore extends JavaPlugin {
         // re-register a scheduled task to update players dynamically
         this.updateTask = getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable() {
             public void run() {
-                for (String name : players.keySet()) {
-                    promote(name);
+                for (UUID uuid : players.keySet()) {
+                    promote(uuid);
                 }
-                saveDB();
+                savePlayersDB();
             }
         }, 1L, 6000L);
 
@@ -199,8 +245,8 @@ public class RankCore extends JavaPlugin {
         this.loginTask = getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable() {
             public void run() {
                 if (logins.size() > 0) {
-                    for (String name : logins) {
-                        promote(name);
+                    for (UUID uuid : logins) {
+                        promote(uuid);
                     }
                     logins.clear();
                 }
@@ -236,8 +282,8 @@ public class RankCore extends JavaPlugin {
     private void buildLeaderboard() {
         debug("Initializing leaderboards...");
         Map<String, Integer> leaders = new LinkedHashMap<String, Integer>();
-        for (String key : getDB().getKeys(false)) {
-            leaders.put(key, getDB().getInt(key));
+        for (String key : getPlayersDB().getKeys(false)) {
+            leaders.put(key, getPlayersDB().getInt(key));
         }
         LinkedList<Map.Entry<String, Integer>> list = new LinkedList<Map.Entry<String, Integer>>(leaders.entrySet());
         Collections.sort(list, new Comparator<Map.Entry<String, Integer>>() {
@@ -294,7 +340,7 @@ public class RankCore extends JavaPlugin {
      * @param name The name of the player we're fetching
      * @return A RankedPlayer object representing the specified player
      */
-    public RankedPlayer getPlayer(String name) {
+    public RankedPlayer getPlayer(UUID name) {
         RankedPlayer player = players.get(name);
         if (player == null) {
             player = promote(name);
@@ -347,23 +393,24 @@ public class RankCore extends JavaPlugin {
      * Adds the specified player name to the login queue
      * @param name The name of the player who has just logged in
      */
-    public void login(final String name) {
-        logins.add(name);
+    public void login(final UUID uuid) {
+        logins.add(uuid);
     }
 
     /**
      * Checks whether the specified player is qualified for a promotion, and promotes them if they are
      * @param name The name of the player
      */
-    public RankedPlayer promote(final String name) {
-        final OfflinePlayer promoted = getServer().getOfflinePlayer(name);
+    public RankedPlayer promote(final UUID uuid) {
+        final OfflinePlayer promoted = getServer().getOfflinePlayer(uuid);
         if (promoted == null) {
             getLogger().warning("Something went wrong... a fetched player was null!");
             return null;
         }
-        RankedPlayer player = players.get(name);
+        final String name = promoted.getName();
+		RankedPlayer player = players.get(uuid);
         if (player == null) {
-            int minutes = getDB().getInt(name.toLowerCase(), 0);
+        	int minutes = getUuidDB().getInt(uuid.toString(), 0);
             Rank rank = getRank(minutes);
             if (rank == null) {
                 getLogger().info("No matching rank was found! Check config.yml for invalid syntax.");
@@ -371,7 +418,7 @@ public class RankCore extends JavaPlugin {
             }
             debug(name + " determined to be " + rank.getName() + " with " + minutes + " minute(s) played.");
             boolean exempt = !promoted.isOnline() || promoted.getPlayer().hasPermission("ranksuite.exempt");
-            player = new RankedPlayer(this, name, rank, minutes, System.currentTimeMillis(), exempt);
+            player = new RankedPlayer(this, name, uuid, rank, minutes, System.currentTimeMillis(), exempt);
         }
         if (player.addTime()) {
             // player is qualified for a promotion
@@ -397,7 +444,7 @@ public class RankCore extends JavaPlugin {
             player.setRank(next);
         }
         if (promoted.isOnline()) {
-            players.put(name, player);
+            players.put(uuid, player);
         }
         return player;
     }
@@ -406,10 +453,10 @@ public class RankCore extends JavaPlugin {
      * Checks for a promotion for the specified player and then destroys their currently loaded object
      * @param name The name of the player who is retiring
      */
-    public void retire(String name) {
-        promote(name);
-        RankedPlayer p = players.remove(name);
-        debug(name + " has retired as a '" + p.getRank().getName() + "'");
+    public void retire(UUID uuid) {
+        promote(uuid);
+        RankedPlayer p = players.remove(uuid);
+        debug(p.getName() + " has retired as a '" + p.getRank().getName() + "'");
     }
 
     /**
@@ -419,14 +466,15 @@ public class RankCore extends JavaPlugin {
      */
     public void checkRank(CommandSender sender, OfflinePlayer player) {
         if (sender.equals(player) || sender.hasPermission("ranksuite.check.other") || !(sender instanceof Player)) {
-            RankedPlayer p = promote(player.getName());
+        	UUID uuid = player.getUniqueId();
+            RankedPlayer p = promote(uuid);
             if (p == null) {
                 sender.sendMessage(ChatColor.RED + "Something went wrong.");
                 return;
             }
             if (p.addTime()) {
                 // user qualified for a promotion
-                promote(player.getName());
+                promote(uuid);
             }
             boolean equal = sender.equals(player);
             String name = (equal ? "You" : player.getName());
@@ -453,9 +501,9 @@ public class RankCore extends JavaPlugin {
      * Resets the specified player to the default rank.
      * @param name The name of the player being reset.
      */
-    public void reset(String name) {
-        RankedPlayer p = getPlayer(name);
-        reset(name, p.getRank().getName());
+    public void reset(UUID uuid) {
+        RankedPlayer p = getPlayer(uuid);
+        reset(uuid, p.getRank().getName());
     }
 
     /**
@@ -463,9 +511,9 @@ public class RankCore extends JavaPlugin {
      * @param name The name of the player
      * @param rank The rank being removed from the player
      */
-    public void reset(String name, String rank) {
+    public void reset(UUID uuid, String rank) {
         Rank base = getRank(0);
-        reset(name, rank, base.getName());
+        reset(uuid, rank, base.getName());
     }
 
     /**
@@ -474,7 +522,8 @@ public class RankCore extends JavaPlugin {
      * @param rank The rank being removed from the player
      * @param base The player's new rank
      */
-    public void reset(String name, String rank, String base) {
+    public void reset(UUID uuid, String rank, String base) {
+    	final String name = Bukkit.getOfflinePlayer(uuid).getName();
         RankSuiteRankResetEvent event = new RankSuiteRankResetEvent(name, base);
         getServer().getPluginManager().callEvent(event);
         Plugin plg = this.getServer().getPluginManager().getPlugin("bPermissions");

--- a/src/main/java/net/krinsoft/ranksuite/RankListener.java
+++ b/src/main/java/net/krinsoft/ranksuite/RankListener.java
@@ -1,5 +1,6 @@
 package net.krinsoft.ranksuite;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -18,12 +19,14 @@ public class RankListener implements Listener {
 
     @EventHandler
     void playerJoin(PlayerJoinEvent event) {
-        plugin.login(event.getPlayer().getName());
+    	Player player = event.getPlayer();
+    	plugin.transfer(player.getName(), player.getUniqueId());
+        plugin.login(player.getUniqueId());
     }
 
     @EventHandler
     void playerQuit(PlayerQuitEvent event) {
-        plugin.retire(event.getPlayer().getName());
+        plugin.retire(event.getPlayer().getUniqueId());
     }
 
 }

--- a/src/main/java/net/krinsoft/ranksuite/RankedPlayer.java
+++ b/src/main/java/net/krinsoft/ranksuite/RankedPlayer.java
@@ -1,5 +1,7 @@
 package net.krinsoft.ranksuite;
 
+import java.util.UUID;
+
 /**
  * @author krinsdeath
  */
@@ -8,14 +10,16 @@ public class RankedPlayer {
     private RankCore plugin;
     private String name;
     private Rank current;
+    private UUID uuid;
     private double minutes;
     private long login;
     private boolean exempt;
 
-    public RankedPlayer(RankCore plugin, String name, Rank rank, int minutes, long login, boolean exempt) {
+    public RankedPlayer(RankCore plugin, String name, UUID uuid, Rank rank, int minutes, long login, boolean exempt) {
         this.plugin = plugin;
         this.name = name;
         this.current = rank;
+        this.uuid = uuid;
         this.minutes = minutes;
         this.login = login;
         this.exempt = exempt;
@@ -38,7 +42,7 @@ public class RankedPlayer {
         this.minutes += ((time - this.login) / 1000 / 60);
         this.login = time;
         if (this.minutes > 0) {
-            plugin.getDB().set(this.name.toLowerCase(), (int) this.minutes);
+        	plugin.getUuidDB().set(this.uuid.toString(), (int) this.minutes);
         }
         if (!exempt && this.current.getNextRank() != null && !this.current.getNextRank().equals("none")) {
             Rank next = plugin.getRank(this.current.getNextRank());
@@ -62,12 +66,12 @@ public class RankedPlayer {
         this.minutes -= mins;
         if (this.minutes < 0) {
             this.minutes = 0;
-            this.plugin.getDB().set(this.name.toLowerCase(), null);
+            this.plugin.getUuidDB().set(this.uuid.toString(), null);
             return;
         }
         Rank down = this.plugin.getRank((int) this.minutes);
         if (!down.getName().equals(this.current.getName())) {
-            plugin.reset(this.name, this.current.getName(), down.getName());
+        	plugin.reset(this.uuid, this.current.getName(), down.getName());
             this.current = down;
         }
         addTime();
@@ -76,9 +80,12 @@ public class RankedPlayer {
     public void reset() {
         this.minutes = 0;
         this.login = System.currentTimeMillis();
-        this.plugin.reset(this.name, this.current.getName());
+        this.plugin.reset(this.uuid, this.current.getName());
         this.current = plugin.getRank(0);
-        this.plugin.getDB().set(this.name.toLowerCase(), null);
+        this.plugin.getUuidDB().set(this.uuid.toString(), null);
     }
 
+    public String getName() {
+    	return this.name;
+    }
 }

--- a/src/main/java/net/krinsoft/ranksuite/commands/AddCommand.java
+++ b/src/main/java/net/krinsoft/ranksuite/commands/AddCommand.java
@@ -41,7 +41,7 @@ public class AddCommand extends BaseCommand {
             sender.sendMessage(ChatColor.RED + "Time added must be a " + ChatColor.GREEN + "positive number" + ChatColor.RED + ".");
             return;
         }
-        plugin.getPlayer(target.getName()).addTime(mins);
+        plugin.getPlayer(target.getUniqueId()).addTime(mins);
         sender.sendMessage(ChatColor.AQUA + String.valueOf(mins) + ChatColor.GREEN + " minute" + (mins > 1 ? "s have" : " has") + " been added to " + ChatColor.AQUA + target.getName() + ChatColor.GREEN + ".");
     }
 

--- a/src/main/java/net/krinsoft/ranksuite/commands/FixCommand.java
+++ b/src/main/java/net/krinsoft/ranksuite/commands/FixCommand.java
@@ -1,6 +1,8 @@
 package net.krinsoft.ranksuite.commands;
 
 import net.krinsoft.ranksuite.RankCore;
+
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
@@ -21,7 +23,8 @@ public class FixCommand extends BaseCommand {
 
     public void runCommand(CommandSender sender, List<String> args) {
         ValidateCommand command = (ValidateCommand) plugin.getCommandHandler().getCommand("validate");
-        boolean reset = command.resetUser(args.get(0));
+        org.bukkit.OfflinePlayer op = Bukkit.getOfflinePlayer(args.get(0));
+        boolean reset = command.resetUser(op.getUniqueId());
         if (reset) {
             sender.sendMessage(ChatColor.GREEN + "The player '" + ChatColor.AQUA + args.get(0) + ChatColor.GREEN + "' was successfully fixed.");
         } else {

--- a/src/main/java/net/krinsoft/ranksuite/commands/RemoveCommand.java
+++ b/src/main/java/net/krinsoft/ranksuite/commands/RemoveCommand.java
@@ -42,6 +42,6 @@ public class RemoveCommand extends BaseCommand {
             sender.sendMessage(ChatColor.RED + "Time removed must be a " + ChatColor.GREEN + "positive number" + ChatColor.RED + ".");
             return;
         }
-        plugin.getPlayer(target.getName()).removeTime(mins);
+        plugin.getPlayer(target.getUniqueId()).removeTime(mins);
         sender.sendMessage(ChatColor.AQUA + String.valueOf(mins) + ChatColor.GREEN + " minute" + (mins > 1 ? "s have" : " has") + " been removed from " + ChatColor.AQUA + target.getName() + ChatColor.GREEN + ".");    }
 }

--- a/src/main/java/net/krinsoft/ranksuite/commands/ResetCommand.java
+++ b/src/main/java/net/krinsoft/ranksuite/commands/ResetCommand.java
@@ -31,7 +31,7 @@ public class ResetCommand extends BaseCommand {
             sender.sendMessage(ChatColor.RED + "No player found with the name '" + ChatColor.GREEN + args.get(0) + ChatColor.RED + "'!");
             return;
         }
-        RankedPlayer player = plugin.getPlayer(target.getName());
+        RankedPlayer player = plugin.getPlayer(target.getUniqueId());
         int time = player.getTimePlayed();
         player.reset();
         sender.sendMessage(ChatColor.AQUA + target.getName() + ChatColor.RED + "'s playtime has been reset!");


### PR DESCRIPTION
Internals were converted to UUIDs, in preparation for Minecraft Name Changing. 
https://forums.bukkit.org/threads/psa-the-switch-to-uuids-potential-plugin-server-breakage.250915/


Important to note that to have a player converted to the new internals, they must log on. 
Once this version is installed, the only thing the old players.db will used for is transferring when they log on. 


RankSuite requires an update to UUIDs so that one cannot lose their playing time because they changed their username. 

This is a re-submitted PR, I simply went back through and patched it for UUIDs instead of fully testing it with the last PR. This code should be ready for production servers, however additional testing may be required to patch small bugs. 